### PR TITLE
update node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "engines" : {
-    "node" : ">=20.0.0"
+    "node" : ">=20.0.0 <24.0.0"
   },
   "dependencies": {
     "@fastify/autoload": "^5.0.0",


### PR DESCRIPTION
This pr updates the node engine to fix deployment issues on heroku.

It seems `buffer-equal-constant-time` doesn't play well with v24:

```
2025-05-08T12:21:46.078403+00:00 app[web.1]: > helloWorld-integration@1.0.0 start
2025-05-08T12:21:46.078405+00:00 app[web.1]: > fastify start -o -a 0.0.0.0 -p $APP_PORT -l info src/app.js
2025-05-08T12:21:46.078406+00:00 app[web.1]: 
2025-05-08T12:21:46.811758+00:00 app[web.1]: TypeError: Cannot read properties of undefined (reading 'prototype')
2025-05-08T12:21:46.811781+00:00 app[web.1]:     at Object.<anonymous> (/app/node_modules/@heroku/salesforce-sdk-nodejs/node_modules/buffer-equal-constant-time/index.js:37:35)
2025-05-08T12:21:46.811781+00:00 app[web.1]:     at Module._compile (node:internal/modules/cjs/loader:1734:14)
2025-05-08T12:21:46.811798+00:00 app[web.1]:     at Object..js (node:internal/modules/cjs/loader:1899:10)
2025-05-08T12:21:46.811798+00:00 app[web.1]:     at Module.load (node:internal/modules/cjs/loader:1469:32)
2025-05-08T12:21:46.811798+00:00 app[web.1]:     at Module._load (node:internal/modules/cjs/loader:1286:12)
2025-05-08T12:21:46.811798+00:00 app[web.1]:     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
2025-05-08T12:21:46.811799+00:00 app[web.1]:     at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
2025-05-08T12:21:46.811799+00:00 app[web.1]:     at Module.require (node:internal/modules/cjs/loader:1491:12)
2025-05-08T12:21:46.811799+00:00 app[web.1]:     at require (node:internal/modules/helpers:135:16)
2025-05-08T12:21:46.811800+00:00 app[web.1]:     at Object.<anonymous> (/app/node_modules/@heroku/salesforce-sdk-nodejs/node_modules/jwa/index.js:1:19)
2025-05-08T12:21:46.848613+00:00 app[web.1]: Error executing command: exit status 1
2025-05-08T12:21:46.892166+00:00 heroku[web.1]: Process exited with status 1
2025-05-08T12:21:46.914522+00:00 heroku[web.1]: State changed from up to crashed
```