### PR TITLE
Ensure forward compatibility

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-# $PORT is used by heroku-integration-service-mesh.  Set $APP_PORT as the app's listening port.
-web: APP_PORT=3000 heroku-integration-service-mesh npm start
+# $PORT is used by heroku-applink-service-mesh.  Set $APP_PORT as the app's listening port.
+web: APP_PORT=3000 heroku-applink-service-mesh npm start


### PR DESCRIPTION
When AppLink ships, the buildpack-installed binary will be available as `heroku-applink-service-mesh` rather than `heroku-integration-service-mesh`.

In heroku/heroku-buildpack-heroku-integration-service-mesh#3, I'm linking the existing binary to the new location. This allows us to start transitioning to the new name which is what this pull request does.